### PR TITLE
fix: Id not present in payload for update subscription

### DIFF
--- a/src/Endpoint/SubscriptionEndpoint.php
+++ b/src/Endpoint/SubscriptionEndpoint.php
@@ -83,7 +83,7 @@ class SubscriptionEndpoint extends AbstractEndpoint
     {
         return $this->rest_update(
             $subscriptionId,
-            $this->createPayloadFromAttributes('subscription', $attributes)
+            $this->createPayloadFromAttributes('subscription', $attributes, $subscriptionId)
         );
     }
 }


### PR DESCRIPTION
Without the id in the payload eCurring returns an error for the update subscription request:

`{"errors":[{"status":"400","code":"RESOURCE_ID_MISSING","title":"Resource ID is missing","detail":"A resource ID must be included in the document!","source":{"pointer":"\/data"}}]}`

The id is required as mentioned in [Update subscription documentation](https://docs.ecurring.com/subscriptions/update).