### PR TITLE
Introduce resourceType per endpoint

### DIFF
--- a/src/Endpoint/AbstractEndpoint.php
+++ b/src/Endpoint/AbstractEndpoint.php
@@ -26,6 +26,12 @@ abstract class AbstractEndpoint
      * @var string
      */
     protected $resourcePath;
+
+    /**
+     * @var string the resource type of the resource object for the endpoint
+     */
+    protected $resourceType;
+
     /**
      * @var string|null
      */
@@ -128,11 +134,18 @@ abstract class AbstractEndpoint
         return $this->resourceFactory->createFromApiResult($result->data, $this->getResourceObject());
     }
 
-    protected function createPayloadFromAttributes(string $type, array $attributes, int $id = 0)
+    /**
+     * Create the data payload for the resource object with the supplied attributes and optionally sets the id.
+     *
+     * @param array $attributes the attributes of the resource to set.
+     * @param int $id (optional) the identifier of the resource to set the attributes for, default 0.
+     * @return array[] containing the data payload.
+     */
+    protected function createPayloadFromAttributes(array $attributes, int $id = 0)
     {
         $payload = [
             'data' => [
-                'type' => $type,
+                'type' => $this->getResourceType(),
                 'attributes' => $attributes
             ]
         ];
@@ -147,6 +160,11 @@ abstract class AbstractEndpoint
     private function getResourcePath(): string
     {
         return $this->resourcePath;
+    }
+
+    private function getResourceType(): string
+    {
+        return $this->resourceType;
     }
 
     private function buildQueryString(array $filters): string

--- a/src/Endpoint/CustomerEndpoint.php
+++ b/src/Endpoint/CustomerEndpoint.php
@@ -14,6 +14,8 @@ class CustomerEndpoint extends AbstractEndpoint
 {
     protected $resourcePath = 'customers';
 
+    protected $resourceType = 'customer';
+
     /**
      * @return AbstractResource
      */
@@ -41,7 +43,7 @@ class CustomerEndpoint extends AbstractEndpoint
     public function create(array $attributes, array $filters = [])
     {
         return $this->rest_create(
-            $this->createPayloadFromAttributes('customer', $attributes),
+            $this->createPayloadFromAttributes($attributes),
             $filters
         );
     }
@@ -79,7 +81,7 @@ class CustomerEndpoint extends AbstractEndpoint
     {
         return $this->rest_update(
             $customerId,
-            $this->createPayloadFromAttributes('customer', $attributes, $customerId)
+            $this->createPayloadFromAttributes($attributes, $customerId)
         );
     }
 }

--- a/src/Endpoint/SubscriptionEndpoint.php
+++ b/src/Endpoint/SubscriptionEndpoint.php
@@ -17,6 +17,8 @@ class SubscriptionEndpoint extends AbstractEndpoint
      */
     protected $resourcePath = 'subscriptions';
 
+    protected $resourceType = 'subscription';
+
     /**
      * @return AbstractResource
      */
@@ -45,7 +47,7 @@ class SubscriptionEndpoint extends AbstractEndpoint
     public function create(int $customerId, int $subscriptionPlanId, array $attributes = [])
     {
         return $this->rest_create(
-            $this->createPayloadFromAttributes('subscription', array_merge([
+            $this->createPayloadFromAttributes(array_merge([
                 'customer_id' => $customerId,
                 'subscription_plan_id' => $subscriptionPlanId
             ], $attributes))
@@ -83,7 +85,7 @@ class SubscriptionEndpoint extends AbstractEndpoint
     {
         return $this->rest_update(
             $subscriptionId,
-            $this->createPayloadFromAttributes('subscription', $attributes)
+            $this->createPayloadFromAttributes($attributes)
         );
     }
 }

--- a/src/Endpoint/SubscriptionPlanEndpoint.php
+++ b/src/Endpoint/SubscriptionPlanEndpoint.php
@@ -14,6 +14,8 @@ class SubscriptionPlanEndpoint extends AbstractEndpoint
 {
     protected $resourcePath = 'subscription-plans';
 
+    protected $resourceType = 'subscription-plan';
+
     /**
      * @return AbstractResource
      */


### PR DESCRIPTION
With the introduction of resourceType per endpoint we no longer have to pass the type to createPayloadFromAttributes.